### PR TITLE
Show warning if bidCpmAdjustment is set for AOL bidder (closes #725) …

### DIFF
--- a/src/adapters/aol.js
+++ b/src/adapters/aol.js
@@ -5,6 +5,7 @@ const bidmanager = require('../bidmanager.js');
 
 const AolAdapter = function AolAdapter() {
 
+  let showCpmAdjustmentWarning = true;
   const pubapiTemplate = template`${'protocol'}://${'host'}/pubapi/3.0/${'network'}/${'placement'}/${'pageid'}/${'sizeid'}/ADTECH;v=2;cmd=bid;cors=yes;alias=${'alias'}${'bidfloor'};misc=${'misc'}`;
   const BIDDER_CODE = 'aol';
   const SERVER_MAP = {
@@ -117,6 +118,18 @@ const AolAdapter = function AolAdapter() {
       const pubapiUrl = _buildPubapiUrl(bid);
 
       ajax(pubapiUrl, response => {
+        // needs to be here in case bidderSettings are defined after requestBids() is called
+        if (showCpmAdjustmentWarning &&
+          $$PREBID_GLOBAL$$.bidderSettings && $$PREBID_GLOBAL$$.bidderSettings.aol &&
+          typeof $$PREBID_GLOBAL$$.bidderSettings.aol.bidCpmAdjustment === 'function'
+        ) {
+          utils.logWarn(
+            'bidCpmAdjustment is active for the AOL adapter. ' +
+            'As of Prebid 0.14, AOL can bid in net – please contact your accounts team to enable.'
+          );
+        }
+        showCpmAdjustmentWarning = false; // warning is shown at most once
+
         if (!response && response.length <= 0) {
           utils.logError('Empty bid response', BIDDER_CODE, bid);
           _addErrorBidResponse(bid, response);

--- a/test/spec/adapters/aol_spec.js
+++ b/test/spec/adapters/aol_spec.js
@@ -1,5 +1,6 @@
 import {expect} from 'chai';
 import _ from 'lodash';
+import * as utils from 'src/utils';
 import AolAdapter from 'src/adapters/aol';
 import bidmanager from 'src/bidmanager';
 
@@ -428,6 +429,37 @@ describe('AolAdapter', () => {
         expect(bidmanager.addBidResponse.calledOnce).to.be.true;
         var bidResponse = bidmanager.addBidResponse.firstCall.args[1];
         expect(bidResponse.cpm).to.equal('a9334987');
+      });
+    });
+
+    describe('when bidCpmAdjustment is set', () => {
+      let bidderSettingsBackup;
+      let server;
+
+      beforeEach(() => {
+        bidderSettingsBackup = $$PREBID_GLOBAL$$.bidderSettings;
+        server = sinon.fakeServer.create();
+      });
+
+      afterEach(() => {
+        $$PREBID_GLOBAL$$.bidderSettings = bidderSettingsBackup;
+        server.restore();
+        if (console.warn.restore) {
+          console.warn.restore();
+        }
+      });
+
+      it('should show warning in the console', function() {
+        sinon.spy(utils, 'logWarn');
+        server.respondWith(JSON.stringify(DEFAULT_PUBAPI_RESPONSE));
+        $$PREBID_GLOBAL$$.bidderSettings = {
+          aol: {
+            bidCpmAdjustment: function() {}
+          }
+        };
+        adapter.callBids(DEFAULT_BIDDER_REQUEST);
+        server.respond();
+        expect(utils.logWarn.calledOnce).to.be.true;
       });
     });
   });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See http://prebid.org/dev-docs/testing-prebid.html for documentation on testing Prebid.js.
-->
## Type of change

<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other
## Description of change

<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids

```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```
- contact email of the adapter’s maintainer
- [ ] official adapter submission
## Other information

<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->

…(#728)
- Show warning if bidCpmAdjustment is set for AOL bidder (closes #725)
- Show bidCpmAdjustment warning for AOL adapter only in debug mode
- Fix failing unit test for AOL adapter
- fix after implementation changed from console.warn to utils.logWarn
